### PR TITLE
MC-30392: De-couple Authorize.net payment methods integrations from core in 2.4.0

### DIFF
--- a/dev/tests/unit/Magento/FunctionalTestFramework/Test/Util/ActionMergeUtilTest.php
+++ b/dev/tests/unit/Magento/FunctionalTestFramework/Test/Util/ActionMergeUtilTest.php
@@ -221,7 +221,7 @@ class ActionMergeUtilTest extends MagentoTestCase
         $actionObjectOne = new ActionObject(
             'actionKey1',
             'magentoCLI',
-            ['command' => 'config:set cms/wysiwyg/enabled {{_CREDS.payment_authorizenet_login}}']
+            ['command' => 'config:set cms/wysiwyg/enabled {{_CREDS.payment_method_login}}']
         );
         $actionObject = [$actionObjectOne];
 
@@ -232,7 +232,7 @@ class ActionMergeUtilTest extends MagentoTestCase
         $expectedValue = new ActionObject(
             'actionKey1',
             'magentoCLISecret',
-            ['command' => 'config:set cms/wysiwyg/enabled {{_CREDS.payment_authorizenet_login}}']
+            ['command' => 'config:set cms/wysiwyg/enabled {{_CREDS.payment_method_login}}']
         );
         $this->assertEquals($expectedValue, $result['actionKey1']);
     }
@@ -248,7 +248,7 @@ class ActionMergeUtilTest extends MagentoTestCase
         $actionObjectOne = new ActionObject(
             'actionKey1',
             'field',
-            ['value' => '{{_CREDS.payment_authorizenet_login}}']
+            ['value' => '{{_CREDS.payment_method_login}}']
         );
         $actionObject = [$actionObjectOne];
 
@@ -259,7 +259,7 @@ class ActionMergeUtilTest extends MagentoTestCase
         $expectedValue = new ActionObject(
             'actionKey1',
             'field',
-            ['value' => '{{_CREDS.payment_authorizenet_login}}']
+            ['value' => '{{_CREDS.payment_method_login}}']
         );
         $this->assertEquals($expectedValue, $result['actionKey1']);
     }

--- a/dev/tests/verification/TestModule/Test/SecretCredentialDataTest.xml
+++ b/dev/tests/verification/TestModule/Test/SecretCredentialDataTest.xml
@@ -14,7 +14,7 @@
             <field key="price">12.34</field>
         </createData>
         <createData entity="_defaultProduct" stepKey="createProductWithFieldOverridesUsingSecretCredData1">
-            <field key="qty">{{_CREDS.payment_authorizenet_trans_key}}</field>
+            <field key="qty">{{_CREDS.payment_method_trans_key}}</field>
             <field key="price">{{_CREDS.carriers_dhl_account_eu}}</field>
         </createData>
 
@@ -22,6 +22,6 @@
         <fillField selector="{{AdminLoginFormSection.username}}" userInput="{{_CREDS.carriers_dhl_id_eu}}" stepKey="fillFieldUsingSecretCredData1"/>
 
         <magentoCLI command="config:set cms/wysiwyg/enabled 0" stepKey="magentoCliUsingHardcodedData1"/>
-        <magentoCLI command="config:set cms/wysiwyg/enabled {{_CREDS.payment_authorizenet_login}}" stepKey="magentoCliUsingSecretCredData1"/>
+        <magentoCLI command="config:set cms/wysiwyg/enabled {{_CREDS.payment_method_login}}" stepKey="magentoCliUsingSecretCredData1"/>
     </test>
 </tests>

--- a/dev/tests/verification/Tests/SecretCredentialDataTest.php
+++ b/dev/tests/verification/Tests/SecretCredentialDataTest.php
@@ -46,7 +46,7 @@ class SecretCredentialDataTestCest
         );
 
         $createProductWithFieldOverridesUsingSecretCredData1Fields['qty'] =
-            $I->getSecret("payment_authorizenet_trans_key");
+            $I->getSecret("payment_method_trans_key");
 
         $createProductWithFieldOverridesUsingSecretCredData1Fields['price'] =
             $I->getSecret("carriers_dhl_account_eu");
@@ -68,7 +68,7 @@ class SecretCredentialDataTestCest
         $I->comment($magentoCliUsingHardcodedData1);
 
         $magentoCliUsingSecretCredData1 = $I->magentoCLI("config:set cms/wysiwyg/enabled " .
-            $I->getSecret("payment_authorizenet_login"));
+            $I->getSecret("payment_method_login"));
             // stepKey: magentoCliUsingSecretCredData1
         $I->comment($magentoCliUsingSecretCredData1);
     }

--- a/etc/config/.credentials.example
+++ b/etc/config/.credentials.example
@@ -19,15 +19,6 @@
 #magento/carriers_dhl_password_eu=
 #magento/carriers_dhl_account_eu=
 
-
-#magento/payment_authorizenet_login=
-#magento/payment_authorizenet_trans_key=
-#magento/payment_authorizenet_trans_md5=
-
-#magento/authorizenet_fraud_review_login=
-#magento/authorizenet_fraud_review_trans_key=
-#magento/authorizenet_fraud_review_md5=
-
 #magento/braintree_enabled_fraud_merchant_account_id=
 #magento/braintree_enabled_fraud_merchant_id=
 #magento/braintree_enabled_fraud_public_key=


### PR DESCRIPTION

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
*Overview*:

We need to de-couple all the deprecated 3rd party payment methods integrations from core in 2.4.0 in order shift maintenance compliance from Magento to the vendors.

*Acceptance criteria*:
 * Remove Authorize.Net Accept.js and Direct Post modules marked as deprecated and other code depended on these modules have to be completely removed from the code base.
 * All the tests related to deprecated Authorize.net payment method have to be removed.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2-functional-testing-framework#<issue_number>, if relevant  -->
1. magento/magento2-functional-testing-framework#<issue_number>: Issue title
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/verification tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 - [ ] Changes to Framework doesn't have backward incompatible changes for tests or have related Pull Request with fixes to tests